### PR TITLE
drawPixel() and fillDisplayArea() now take larger, signed args

### DIFF
--- a/firmware/user/display/oled.c
+++ b/firmware/user/display/oled.c
@@ -155,9 +155,9 @@ void ICACHE_FLASH_ATTR clearDisplay(void)
  * @param y2
  * @param c
  */
-void ICACHE_FLASH_ATTR fillDisplayArea(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, color c)
+void ICACHE_FLASH_ATTR fillDisplayArea(int16_t x1, int16_t y1, int16_t x2, int16_t y2, color c)
 {
-    uint8_t x, y;
+    int16_t x, y;
     for (x = x1; x <= x2; x++)
     {
         for (y = y1; y <= y2; y++)
@@ -168,25 +168,16 @@ void ICACHE_FLASH_ATTR fillDisplayArea(uint8_t x1, uint8_t y1, uint8_t x2, uint8
 }
 
 /**
- * @brief Copy an entire frame's worth of pixels to the framebuffer
- *
- * @param frame The frame to copy into the frameBuffer
- */
-void ICACHE_FLASH_ATTR drawFrame(const uint8_t* frame)
-{
-    memcpy(currentFb, frame, sizeof(currentFb));
-}
-
-/**
  * Set/clear/invert a single pixel.
  *
  * @param x Column of display, 0 is at the left
  * @param y Row of the display, 0 is at the top
  * @param c Pixel color, one of: BLACK, WHITE or INVERT
  */
-void ICACHE_FLASH_ATTR drawPixel(uint8_t x, uint8_t y, color c)
+void ICACHE_FLASH_ATTR drawPixel(int16_t x, int16_t y, color c)
 {
-    if ((x < OLED_WIDTH) && (y < OLED_HEIGHT))
+    if ((0 <= x) && (x < OLED_WIDTH) &&
+            (0 <= y) && (y < OLED_HEIGHT))
     {
         x = (OLED_WIDTH - 1) - x;
         y = (OLED_HEIGHT - 1) - y;

--- a/firmware/user/display/oled.h
+++ b/firmware/user/display/oled.h
@@ -21,10 +21,9 @@ typedef enum
 #define OLED_HEIGHT 64
 
 bool initOLED(bool reset);
-void drawPixel(uint8_t x, uint8_t y, color c);
-void drawFrame(const uint8_t* frame);
+void drawPixel(int16_t x, int16_t y, color c);
 bool updateOLED(void);
 void clearDisplay(void);
-void fillDisplayArea(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, color c);
+void fillDisplayArea(int16_t x1, int16_t y1, int16_t x2, int16_t y2, color c);
 
 #endif /* OLED_H_ */


### PR DESCRIPTION
Remove drawFrame(), it was unused